### PR TITLE
Update link: bs4_cdn

### DIFF
--- a/htmltools-dependencies.Rmd
+++ b/htmltools-dependencies.Rmd
@@ -48,7 +48,7 @@ knitr::include_graphics("images/htmltools/bs4-card-dirty.png")
 As depicted by Figure \@ref(fig:bs4-card-dirty), nothing is displayed which was expected since `{shiny}` [@R-shiny] does not contain Bootstrap 4 dependencies. Don't panic! We load the necessary css to display this card (if required, we could include the javascript as well). We could use either `includeCSS()`, `tags$head(tags$link(rel = "stylesheet", type = "text/css", href = "custom.css"))`, as described in the shiny documentation [here](https://shiny.rstudio.com/articles/css.html). Web development best practice recommend to point to external file rather than including CSS in the head or as inline CSS (see chapter \@ref(beautify-css)). In the below example, we use a __CDN__ (content delivery network) but that could be a local file in the `www/` folder:  
 
 ```{r}
-bs4_cdn <- "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/"
+bs4_cdn <- "https://stackpath.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
 bs4_css <- paste0(bs4_cdn, "css/bootstrap.min.css")
 ```
 


### PR DESCRIPTION
I noticed the link didn't work, searched for "bootstrapcdn", and found this link in the old versions.