### PR TITLE
Chapter 10 updates

### DIFF
--- a/custom-templates-dependencies.Rmd
+++ b/custom-templates-dependencies.Rmd
@@ -1,9 +1,9 @@
 # Define dependencies {#custom-templates-dependencies}
-The Tabler template is a tiny __Bootstrap 4__ dashboard template. In this chapter, we will describe how to create an R wrapper on top of it, thereby making it available for all shiny users. 
+The Tabler template is a tiny __Bootstrap 4__ dashboard template. In this chapter, we will describe how to create an R wrapper on top of it, thereby making it available for all shiny users.
 
 ::: {.importantblock data-latex=""}
-This chapter was written about two years ago, on top of the __1.0.0-alpha.7__ Github [release](https://github.com/tabler/tabler/tree/14d0c001436b85d2a4533d63680d209affdf774b). 
-If the Tabler library significantly evolved since that date, the way to incorporate it into 
+This chapter was written about two years ago, on top of the __1.0.0-alpha.7__ Github [release](https://github.com/tabler/tabler/tree/14d0c001436b85d2a4533d63680d209affdf774b).
+If the Tabler library significantly evolved since that date, the way to incorporate it into
 the shiny ecosystem remains __unchanged__. Hence, the methods we describe below may be __generalized__ to other
 templates. We recommend to read this chapter before the next part in \@ref(workflow-charpente), during
 which we present a more automated workflow, if you want to grasp the main concepts.
@@ -11,26 +11,26 @@ which we present a more automated workflow, if you want to grasp the main concep
 
 ## Discover the project
 The first step of any template adaptation consists of __exploring__ the underlying Github [repository](https://github.com/tabler/tabler/tree/14d0c001436b85d2a4533d63680d209affdf774b)
-and look for mandatory elements, like CSS/JS __dependencies__. 
-This is a similar strategy if you want to incorporate an htmlwidget as well. 
+and look for mandatory elements, like CSS/JS __dependencies__.
+This is a similar strategy if you want to incorporate an htmlwidget as well.
 
 As depicted by Figure \@ref(fig:tabler-github), the most important folders are:
 
-  - __dist__, which contains CSS and JS files as well as other libraries like Bootstrap and jQuery. 
+  - __dist__, which contains CSS and JS files as well as other libraries like Bootstrap and jQuery.
   It is also a good moment to look at the version of each dependency that might conflict with Shiny.
-  - __demo__ is the website folder used for demonstration purpose. 
+  - __demo__ is the website folder used for demonstration purpose.
   This is our source to explore the template capabilities in depth.
-  
-The __scss__ and __build__ folder may be used to customize the tabler template directly. However as stated above, directions on how to do so are out of scope for this book.  
+
+The __scss__ and __build__ folder may be used to customize the tabler template directly. However as stated above, directions on how to do so are out of scope for this book.
 
 ```{r tabler-github, echo=FALSE, fig.cap='Github project exploration', out.width='100%'}
 knitr::include_graphics("images/practice/tabler-github.png")
 ```
 
 ## Identify mandatory dependencies
-`Bootstrap 4`, `jQuery`, `tabler.min.css` and `tabler.min.js` are key elements for the template, 
-contrary to flag icons which are optional (and take a lot of space). 
-If your goal is to release your template on CRAN, be mindful of the 5 Mb maximum size limit. 
+`Bootstrap 4`, `jQuery`, `tabler.min.css` and `tabler.min.js` are key elements for the template,
+contrary to flag icons which are optional (and take a lot of space).
+If your goal is to release your template on CRAN, be mindful of the 5 Mb maximum size limit.
 From personal experience, I can attest that this is quite challenging to manage.
 
 To inspect dependencies, we proceed as follows:
@@ -38,10 +38,10 @@ To inspect dependencies, we proceed as follows:
   - __Download__ or __clone__ the Github repository.
   - Go to the __demo folder__ and open the `layout-dark.html` file.
   - Open the __HTML inspector__.
-  
-As shown on Figure \@ref(fig:tabler-deps) left-hand side, we need to include the `tabler.min.css` from the header. If you are not convinced, try to remove it from the DOM and see what happens. [jqvmap](https://www.10bestdesign.com/jqvmap/) is actually related to an external visualization plugin used in the demo. Finally the `demo.min.css` file is for the demo purpose. 
+
+As shown on Figure \@ref(fig:tabler-deps) left-hand side, we need to include the `tabler.min.css` from the header. If you are not convinced, try to remove it from the DOM and see what happens. [jqvmap](https://www.10bestdesign.com/jqvmap/) is actually related to an external visualization plugin used in the demo. Finally the `demo.min.css` file is for the demo purpose.
 This will not prevent the template from working, so we will skip it for now. So far so good, we only need one file thus!
-  
+
 ```{r tabler-deps, echo=FALSE, fig.show = "hold", out.width = "50%", fig.align = "default"}
 knitr::include_graphics("images/practice/tabler-deps-1.png")
 knitr::include_graphics("images/practice/tabler-deps-2.png")
@@ -50,7 +50,7 @@ knitr::include_graphics("images/practice/tabler-deps-2.png")
 JavaScript dependencies are shown on the right-hand side and located at the end of the body tag. Because we will not need all chart-related dependencies like `apexcharts`, `jquery.vmap` and `vmap world`, we may safely ignore them. We only retain the Bootstrap 4, jQuery core and `tabler.min.js`, in the same order.
 
 ## Bundle dependencies
-With the help of the `htmlDependency()` function, we are going to create our main Tabler HTML dependency containing all assets to allow our template to render properly. In this example, we are going to cheat a bit: instead of handling local files, we will use a CDN (content delivery network) that hosts all necessary Tabler [assets](https://www.jsdelivr.com/package/npm/tabler). This avoids to include all the necessary files in the R package, as well as in a github repository. 
+With the help of the `htmlDependency()` function, we are going to create our main Tabler HTML dependency containing all assets to allow our template to render properly. In this example, we are going to cheat a bit: instead of handling local files, we will use a CDN (content delivery network) that hosts all necessary Tabler [assets](https://www.jsdelivr.com/package/npm/tabler). This avoids to include all the necessary files in the R package, as well as in a github repository.
 
 ::: {.warningblock data-latex=""}
 For a __production__ template, that is designed to go on CRAN,
@@ -68,7 +68,7 @@ tablers_deps <- htmlDependency(
 )
 ```
 
-We advise the reader to create one HTML dependency per element. The Bootstrap version is `4.3.1` and jQuery is `3.5.0`. We can also use a CDN:
+We advise the reader to create one HTML dependency per element. The Bootstrap version is `4.3.1` and jQuery is `3.6.0`. We can also use a CDN:
 
 ```{r}
 bs4_deps <- htmlDependency(
@@ -80,9 +80,9 @@ bs4_deps <- htmlDependency(
 
 jQuery_deps <- htmlDependency(
   name = "jquery",
-  version = "3.5.0",
+  version = "3.6.0",
   src = c(href = "https://code.jquery.com/"),
-  script = "jquery-3.5.0.slim.min.js"
+  script = "jquery-3.6.0.slim.min.js"
 )
 ```
 
@@ -97,9 +97,9 @@ add_tabler_deps <- function(tag) {
 }
 ```
 
-Notice the dependencies order in the `deps` list. This will be exactly the same order in the `head` of the HTML page. Some libraries require to be loaded at a specific place, like the Tabler dependencies which must come after Bootstrap. 
+Notice the dependencies order in the `deps` list. This will be exactly the same order in the `head` of the HTML page. Some libraries require to be loaded at a specific place, like the Tabler dependencies which must come after Bootstrap.
 
-Let's see how to use `add_tabler_deps()`. We consider a `<div>` placeholder and check for its dependencies with `findDependencies()`. 
+Let's see how to use `add_tabler_deps()`. We consider a `<div>` placeholder and check for its dependencies with `findDependencies()`.
 Then, we wrap it with `add_tabler_deps()`:
 
 ```{r}
@@ -109,7 +109,7 @@ tag <- add_tabler_deps(div())
 findDependencies(tag)
 ```
 
-As shown above, our dependencies are applied to the div, in the correct order. This order is set by the list `list(bs4_deps, jQuery_deps, tablers_deps)` and allows use to avoid potential __conflicts__. If we try to run this simple tag in a shiny app, we notice that all dependencies are added to the `<head>` tag, whereas the original template loads JavaScript dependencies in the `<body>`. 
+As shown above, our dependencies are applied to the div, in the correct order. This order is set by the list `list(bs4_deps, jQuery_deps, tablers_deps)` and allows use to avoid potential __conflicts__. If we try to run this simple tag in a shiny app, we notice that all dependencies are added to the `<head>` tag, whereas the original template loads JavaScript dependencies in the `<body>`.
 
 ::: {.noteblock data-latex=""}
 Unfortunately, `{htmltools}` does not allow developers to distribute dependencies in different places yet.

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -505,7 +505,7 @@ btn.addEventListener('click', function() {
     <meta charset="utf-8">
     <title>Including jQuery</title>
     <!-- How to include jQuery -->
-    <script src="https://code.jquery.com/jquery-3.5.0.js">
+    <script src="https://code.jquery.com/jquery-3.5.1.js">
     </script>
   </head>
   <body>

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -300,7 +300,7 @@ In arrays, elements may be accessed by their __index__, but as mentioned before,
 For instance, if we want to get the first element of the `nested` array, we do:
 
 ```js
-console.log(nested[0];
+console.log(nested[0]);
 // To get deeply nested element
 // we may chain index
 nested[1][1] // Access [1, 2, 3]
@@ -618,7 +618,7 @@ Below is a list of the main jQuery [methods](https://api.jquery.com/category/man
 | removeClass() | Remove class or multiple classes to the set of matched elements |
 | attr() | Get or set the value of a specific attribute |
 | after() | Insert content after |
-| before () | Insert content before |
+| before() | Insert content before |
 | css() | Get or set a CSS property |
 | remove() | Remove element(s) from the DOM |
 | val() | Get the current value of the matched element(s) |

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -892,7 +892,7 @@ code, share and more. It also does not require you to have any specific configur
 
 This is a very basic HTML skeleton
 
-3. In the JavaScript windows, select jQuery 3.4.1 in the dropdown menu (why 3.4.1? The latest Shiny release relies on that version. It is therefore best practice to ensure dependencies are similar, at least the major version).
+3. In the JavaScript windows, select jQuery 3.5.1 in the dropdown menu (why 3.5.1? The latest Shiny release (v1.6.0) relies on that version. It is therefore best practice to ensure dependencies are similar, at least the major version).
 4. Since it is best practice to run jQuery code only when the document is ready (avoiding to target non existing elements), we wrap our JS code in the following:
 
 ```js

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -601,8 +601,8 @@ There exist filtering functions dedicated to simplify item [selection](https://a
 | first() | Given an list of elements, select the first item |
 | last() | Given an list of elements, select the last item |
 | find() | Look for a descendant of the selected element(s) that could be multiple levels down in the DOM |
-| closest() | Returns the first ancestor matching the condition (travels up in the DOM) |
-| filter() | Fine tune element selection by applying a filter. Only return element for which the condition is true |
+| closest() | Returns the first ancestor (including itself) matching the condition (travels up in the DOM) |
+| filter() | Fine tune element selection by applying a filter. Only return elements for which the condition is true |
 | siblings() | Get all siblings of the selected element(s) |
 | next() | Get the immediately following sibling |
 | prev() | Get the immediately preceding sibling |

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -157,7 +157,7 @@ console.log(myVariable);
 All mathematical operators apply, for example:
 
 ```js
-let myNumber = 1; // affectation
+let myNumber = 1; // initialize
 myNumber--; // decrement
 console.log(myNumber); // print 0
 ```
@@ -841,7 +841,7 @@ Because the JavaScript console is a REPL, all JavaScript exercises may be done i
 1. Play with the example below
 
 ```{js}
-let myNumber = 1; // affectation
+let myNumber = 1; // initialize
 myNumber--; // decrement
 console.log(myNumber); // print 0
 ```

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -397,7 +397,7 @@ letters.forEach((letter) => {
 
 Since arrays are objects, it is not surprising to see `array.forEach(element, ...)`.
 
-What `for` loop should we use? The answer is: it depends on the situation! Actually, there even exists other ways (replace `of` by `in` and you get the indexes of the array, like with the first code, but this is really [not recommended](https://hacks.mozilla.org/2015/04/es6-in-depth-iterators-and-the-for-of-loop/)).
+Which `for` loop should we use? The answer is: it depends on the situation! Actually, there even exists other ways (replace `of` by `in` and you get the indexes of the array, like with the first code, but this is really [not recommended](https://hacks.mozilla.org/2015/04/es6-in-depth-iterators-and-the-for-of-loop/)).
 
 #### Other iterations: while
 While loops are another way to iterate, the incrementation step taking place at the end of the instruction:
@@ -464,7 +464,7 @@ import { findMax, ...} from './utils.js'; // in test.js
 ```
 
 ### JS code compatibility
-As ES6 is not fully supported by all web browsers, you might wonder how to make your JS code standard. There exists tools called __transpiler__, that convert any modern JS code into a universal JS code. This is the case of [Babel](https://babeljs.io/), one of the most commonly used. In chapter \@ref(workflow-charpente), we'll see how to do it with a JS __bundler__, namely`esbuild`.
+As ES6 is not fully supported by all web browsers, you might wonder how to make your JS code standard. There exists tools called __transpiler__, that convert any modern JS code into a universal JS code. This is the case of [Babel](https://babeljs.io/), one of the most commonly used. In chapter \@ref(workflow-charpente), we'll see how to do it with a JS __bundler__, namely `esbuild`.
 
 ### Event listeners
 When you explore a web application, clicking on a button usually triggers something like a computation, a modal or an alert. How does this work? In JavaScript, interactivity plays a critical role. Indeed, you want the web application to react to user inputs like mouse clicks or keyboard events. Below we introduce DOM __events__.
@@ -745,7 +745,7 @@ Object.defineProperty(object1, 'print', {
 
 
 ## Shiny, JavaScript and the HTML inspector {#shiny-js-inspector}
-In the above part, we provided some elementary JS knowledge. This section comes back to the main point of this book, that is Shiny. We describe how to leverage the developer tools so as to test, run and debug JavaScript code related to a Shiny app.
+In the part above, we provided some elementary JS knowledge. This section comes back to the main point of this book, that is Shiny. We describe how to leverage the developer tools so as to test, run and debug JavaScript code related to a Shiny app.
 
 ### The console panel
 While developing JS code, we often put some `console.log(var)` calls to track the content of a given variable and check that our code is doing what it is supposed to do. The resulting messages, errors or warnings are printing in the console, also called a Read-eval-print loop (__REPL__), suitable to experiment and practice your new JS/jQuery skills.
@@ -861,7 +861,7 @@ const me = {
 }
 ```
 
-1. Fill it with some random values.
+1. Fill in the objection with some random values.
 2. Access the `name` property.
 3. Create the `printAge` method, which returns the `age`. Hint: `this` refers to the object itself. For instance `this.name` gives the name property.
 

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -403,7 +403,8 @@ Which `for` loop should we use? The answer is: it depends on the situation! Actu
 While loops are another way to iterate, the incrementation step taking place at the end of the instruction:
 
 ```js
-const h = 3; i = 0;
+const h = 3;
+let i = 0;
 while (i <= h) {
   console.log(i);
   i++; // we need to increment to avoid infinite loop

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -319,7 +319,7 @@ Below is a table referencing the principal methods for arrays.
 | Method/Property   |      Description     |
 |:----------:|:-------------:|
 | length |  Return the number of elements in an array  |
-| Join(string separator) |  Transform an array in a string |
+| join(separator) | Transform an array into a single string |
 | concat(array1, array2) |    Assemble 2 arrays   |
 | pop() | Remove the last element of an array |
 | shift() | Remove the first element of an array |

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -362,7 +362,7 @@ All classic functions like `sqrt`, trigonometric functions are of course availab
 Iterations allow to repeat an instruction or a set of instructions multiple times. Let's assume we have an array containing 100,000 random numbers. How would you do to automatically print them? This is what we are going to see below!
 
 #### For loops
-The for __loop__ has multiple uses. A convenient way to print all array's elements is to use an iteration:
+The __for loop__ has multiple uses. A convenient way to print all array's elements is to use an iteration:
 
 ```js
 // ES6 syntax
@@ -475,7 +475,7 @@ Let's consider a basic HTML button:
 <button id="mybutton">Go!</button>
 ```
 
-On the JavaScript side, we first capture the button element using its id selector with `getElementById`:.
+On the JavaScript side, we first capture the button element using its `id` selector with `getElementById`:.
 
 ```js
 const btn = document.getElementById('mybutton');
@@ -525,7 +525,7 @@ Below is a minimal jQuery code representing its philosophy ("write less, do more
 ```js
 $(selector).action();
 ```
-The __selector__ slot stands for any jQuery selector like class, id, element, [attribute], :input (will select all input elements) and many [more](https://www.w3schools.com/jquery/jquery_ref_selectors.asp). As a reminder, let's consider the following example:
+The __selector__ slot stands for any jQuery selector like `class`, `id`, `element`, `[attribute]`, `:input` (will select all `<input>` elements) and many [more](https://www.w3schools.com/jquery/jquery_ref_selectors.asp). As a reminder, let's consider the following example:
 
 ```html
 <p class="text">Hello World</p>
@@ -862,8 +862,8 @@ const me = {
 ```
 
 1. Fill it with some random values.
-2. Access the name property.
-3. Create the printAge method, which returns the age. Hint: `this` refers to the object itself. For instance `this.name` gives the name property.
+2. Access the `name` property.
+3. Create the `printAge` method, which returns the `age`. Hint: `this` refers to the object itself. For instance `this.name` gives the name property.
 
 ### Exercise 3: jQuery
 [JSFiddle](https://jsfiddle.net/) allows to insert HTML, CSS and JavaScript to test
@@ -907,7 +907,7 @@ $(document).ready(function() {
 ```
 
 5. Create an event listener to change the third item color as soon as one click on it.
-Hint 1: To select the a specific item you may use `$(selector:eq(i))` where i is the index of the element. Keep in mind that JavaScript starts from 0 and not 1 like R!
+Hint 1: To select the a specific item you may use `$(selector:eq(i))` where `i` is the index of the element. Keep in mind that JavaScript starts from 0 and not 1 like R!
 Hint 2: as a reminder, to create an event listener in jQuery, we use the following pattern.
 
 ```js
@@ -949,8 +949,7 @@ $(function() {
 
     // show alert given condition
     if (val > 3) {
-      // do whatever you want
-    	...
+      ...
     }
   });
 

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -626,7 +626,7 @@ Below is a list of the main jQuery [methods](https://api.jquery.com/category/man
 
 
 ### Chaining jQuery methods
-A lot of jQuery methods may be chained, that is like pipe operations in R.
+A lot of jQuery methods may be chained, similar to using a pipe operation in R.
 
 ```html
 <ul>

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -626,7 +626,7 @@ Below is a list of the main jQuery [methods](https://api.jquery.com/category/man
 
 
 ### Chaining jQuery methods
-A lot of jQuery methods may be chained, similar to using a pipe operation in R.
+A lot of jQuery methods may be chained from one method to the next using a `.`.
 
 ```html
 <ul>

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -31,7 +31,7 @@ There are three ways to include scripts in an HTML document:
 
   - Use the `<script>` tag with the JS code inside.
   - Add the `onclick` attribute to an HTML tag (preferably a button) to trigger JS as soon as it is clicked.
-  - Import an external file containing the JS code and only.
+  - Import an external file containing the JS code only.
 
 ```html
 <script type="text/javascript">
@@ -48,7 +48,7 @@ There are three ways to include scripts in an HTML document:
 <script type="text/javascript" src="file.js">
 ```
 
-Whether to choose the first, second or third method depends on the content of your script. If we consider the JS library jQuery, it unfortunately contains so much code making it a challenge to understand. This make user chose the third method, most of the time.
+Whether to choose the first, second, or third method depends on the content of your script. If we consider the JS library jQuery, it unfortunately contains so much code making it a challenge to understand. This make user chose the third method, most of the time.
 
 ## Setup
 Like [R](https://www.r-project.org/) or [Python](https://www.python.org/), JavaScript (JS) is an __interpreted__ language. It is executed __client-side__, in other words in the browser. This also means that JS code may not be run without a suitable tool. In the following, we'll list some tools to test JS code, even though JS may also be run through the web browser developer tools, as demonstrated in section \@ref(shiny-js-inspector).
@@ -76,7 +76,7 @@ Let's write our first script:
 console.log("Hello World");
 ```
 
-You notice that all instruction end by `;`. You can run this script either in RStudio IDE or VSCode.
+You notice that all instructions end with a `;`. You can run this script either in RStudio IDE or VSCode.
 
 ```{r script-vscode, echo=FALSE, fig.cap='Run JS in VSCode', out.width='100%'}
 knitr::include_graphics("images/survival-kit/script-vscode.png")
@@ -89,7 +89,7 @@ knitr::include_graphics("images/survival-kit/script-rstudio.png")
 ```
 
 ## Programming with JS: basis
-We are now all set to introduce the basis of JS. As many languages, JS is made of __variables__ and __instructions__. All instructions end by the `;` symbol.
+We are now all set to introduce the basis of JS. As many languages, JS is made of __variables__ and __instructions__. All instructions end with a `;` symbol.
 
 ### JS types
 JS defines several __types__:
@@ -207,7 +207,7 @@ Below are the operators to check conditions:
 :::
 
 ::: {.importantblock data-latex=""}
-Importantly, prefer `===` and `!==` to compare elements since `5 == "5"` would return `true`, generally not what you want!
+Importantly, prefer `===` and `!==` to compare elements since `5 == "5"` would return `true`, which is generally not what you want!
 :::
 
 
@@ -359,7 +359,7 @@ All classic functions like `sqrt`, trigonometric functions are of course availab
 
 
 ### Iterations
-Iterations allow to repeat an instruction or a set of instructions multiple times. Let's assume we have an array containing 100000 random numbers. How would you do to automatically print them? This a what we are going to see below!
+Iterations allow to repeat an instruction or a set of instructions multiple times. Let's assume we have an array containing 100,000 random numbers. How would you do to automatically print them? This is what we are going to see below!
 
 #### For loops
 The for __loop__ has multiple uses. A convenient way to print all array's elements is to use an iteration:
@@ -422,7 +422,7 @@ const fun = (parm1, parm2) => {
   return Math.max(parm1, parm2);
 }
 let res = fun(1, 2);
-console.log(res); // prints a and 2. a global
+console.log(res); // prints a and 2
 console.log(p); // fails as p was defined inside the function
 ```
 
@@ -569,7 +569,7 @@ let lists = $('ul');
 let firstItem = $('#list2:first-child');
 ```
 
-The very good new is that you should already be at ease with CSS selectors from section \@ref(css-selectors)!
+The good news is that you should already be at ease with CSS selectors from section \@ref(css-selectors)!
 
 ### Good practice
 It is recommended to wrap any jQuery code as follows:
@@ -605,11 +605,11 @@ There exist filtering functions dedicated to simplify item [selection](https://a
 | siblings() | Get all siblings of the selected element(s) |
 | next() | Get the immediately following sibling |
 | prev() | Get the immediately preceding sibling |
-| not() | Given an existing set of selected elements, remove element(s) that match the given condition |
+| not() | Given an existing set of selected elements, exclude element(s) that match the given condition |
 
 
 #### Manipulate tags
-Below is a list of the main jQuery [methods](https://api.jquery.com/category/manipulation/) to manipulate tags (adding class, css property...)
+Below is a list of the main jQuery [methods](https://api.jquery.com/category/manipulation/) to manipulate tags (adding class, CSS property...)
 
 | Method   |     Description     |
 |:----------:|:-------------:|
@@ -619,7 +619,7 @@ Below is a list of the main jQuery [methods](https://api.jquery.com/category/man
 | attr() | Get or set the value of a specific attribute |
 | after() | Insert content after |
 | before () | Insert content before |
-| css() | Get or set a css property |
+| css() | Get or set a CSS property |
 | remove() | Remove element(s) from the DOM |
 | val() | Get the current value of the matched element(s) |
 
@@ -695,13 +695,13 @@ $(element).change(); // trigger change on an element
 // attach an event handler function.
 // Here we add click
 $(element).on('click', function() {
- // whatever
+  // handle event
 });
 
 
 // one triggers only once
 $(element).one('click', function() {
- // whatever
+  // handle event
 });
 
 // useful to trigger plot resize in Shiny so that
@@ -772,7 +772,7 @@ A lot of Shiny app issues on [Stack Overflow](https://stackoverflow.com/) or in 
 
 ### Debug Shiny/JS code with the inspector {#broken-shiny-app-debug}
 To debug Shiny apps from the inspector, all your scripts have to be in a folder accessible by the app like the `www/` folder or by using `addResourcePath()`. Moreover,
-if you have minified files, there should be [source maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/), which will allow to reconstruct the original scripts, that is as they were before the minification process. For instance, Shiny has the `shiny.min.js.map`. In practice, most R packages bundling HTML templates do not ship these files since they could be quite large (> 1.5MB) and CRAN restricts the package size to 5MB. For instance, the [framework7](https://framework7.io/) HTML template, on top of which is built `{shinyMobile}` [R-shinyMobile] has source maps but the size can reach 5MB which is obviously too big to include in the R package.
+if you have minified files, there should be [source maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/), which will allow to reconstruct the original scripts, that is as they were before the minification process. For instance, Shiny has the `shiny.min.js.map`. In practice, most R packages bundling HTML templates do not ship these files since they could be quite large (> 1.5MB) and CRAN restricts the package size to 5MB. For instance, the [framework7](https://framework7.io/) HTML template, which `{shinyMobile}` is built on [@R-shinyMobile], has source maps but the size woudl exceed 5MB which is obviously too big to include in the R package.
 
 In the following, we consider a very simple shiny app deployed on [shinyapps.io](https://www.shinyapps.io/), where a notification is displayed with JavaScript as soon as a user clicks an action button. We deliberately made some typos, the goal being to find and fix them.
 
@@ -780,7 +780,7 @@ In the following, we consider a very simple shiny app deployed on [shinyapps.io]
   2. Open the Chrome DevTools
   3. Click on the action button (I am pretty sure you clicked before step 2 ;))
   4. As expected and shown Figure \@ref(fig:dom-debug-shiny-error), the console displays an
-  error message: `Uncaught TypeError: Cannot read property 'show' of undefined`. Sounds good isn't it?
+  error message: `Uncaught TypeError: Cannot read property 'show' of undefined`. Sounds good doesn't it?
 
 ```{r dom-debug-shiny-error, echo=FALSE, fig.cap='Error in the console panel', out.width='100%'}
 knitr::include_graphics("images/survival-kit/dom-debug-shiny-error.png")

--- a/shiny-javascript.Rmd
+++ b/shiny-javascript.Rmd
@@ -165,7 +165,7 @@ console.log(myNumber); // print 0
 ::: {.noteblock data-latex=""}
 List of numerical operators in JS:
 
-  - `+`. `+` also allows to concatenate strings together.
+  - `+` (also allows to concatenate strings together)
   - `-`
   - `*`
   - `/`


### PR DESCRIPTION
I'm not sold on the `Adjust pipe operation phrasing` commit. I'm wondering if it is just best to say 

```
A lot of jQuery methods may be chained from one method to the next using a `.`.
```

... and not try to draw parallels with `%>%`.  It is more similar to `$` than `%>%` in reality. (Ex: R6 suggesting to return self to chain functions together: https://r6.r-lib.org/articles/Introduction.html)