### PR TITLE
Remove `getState()` description

### DIFF
--- a/shiny-input-system.Rmd
+++ b/shiny-input-system.Rmd
@@ -505,7 +505,6 @@ There are a couple of methods not described above that are contained in the `Inp
 
   - __getId__ returns the object id (Figure \@ref(fig:binding-getId)). If you don't provide your own method, the binding falls back to the default one provided in the `InputBinding` class. This method is called after `find`. The next Chapter \@ref(shiny-input-lifecycle) provides more details. 
   - __getType__ required to handle custom data format. It is called after `getId`. A entire section \@ref(custom-data-format) is dedicated.
-  - __getState__ ?
   
 ```{r binding-getId, echo=FALSE, fig.cap='The binding getId method', out.width='100%'}
 knitr::include_graphics("images/survival-kit/binding-getId.png")


### PR DESCRIPTION
It does not seem like it is used. Better to remove than expose. Fixes #50