### PR TITLE
Chapter 27

### DIFF
--- a/mobile-going-further.Rmd
+++ b/mobile-going-further.Rmd
@@ -48,6 +48,7 @@ $(document).on("shiny:disconnected", function(event) {
 In the next step, we to remove the default shiny reconnect elements. They are inserted by the `onDisconnected` method, that adds a disconnect overlay (gray-out screen) and optionally a reconnect notification:
 
 ```js
+// From within Shiny.shinyapp...
 this.onDisconnected = function() {
   // Add gray-out overlay, if not already present
   var $overlay = $('#shiny-disconnected-overlay');

--- a/mobile-going-further.Rmd
+++ b/mobile-going-further.Rmd
@@ -73,7 +73,7 @@ this.onDisconnected = function() {
 }
 ```
 
-To remove them, there are multiple alternatives. The easiest way is to wait
+To remove default shiny reconnect elements, there are multiple alternatives. The easiest way is to wait
 for the client to be connected, that is listening to `shiny:connected`, and set the `Shiny.shinyapp.onDisconnected` method to only add the gray overlay. 
 
 ::: {.importantblock data-latex=""}

--- a/mobile-going-further.Rmd
+++ b/mobile-going-further.Rmd
@@ -100,7 +100,6 @@ We edit the previous disconnected event listener to add a custom Framework7 toas
 $(document).on("shiny:disconnected", function(event) {    
   let reconnectToast = app.toast
     .create({
-      icon: '<i class="icon f7-icons">bolt_fill</i>',
       position: "center",
       text:
         `Oups... disconnected </br> </br> 


### PR DESCRIPTION
There is no icon in https://github.com/DivadNojnarg/outstanding-shiny-ui-code/blob/e9d175706d5e7f192d67c63ac2c3ed89e6da5a6d/srcjs/helpers_disconnect.js#L15-L19 . Remove it to match the final application. (The icon font family is not loaded and displayed as text)